### PR TITLE
fix(cli): honor --pose when --glb/--colmap is present

### DIFF
--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -141,6 +141,13 @@ static int cmd_depth_export(const da::cli::Parsed& p, da::Engine& eng){
             std::fprintf(stderr, "error: write_colmap failed\n"); return 1; }
         std::printf("wrote COLMAP model (%s) to %s\n", p.colmap_binary ? "bin" : "txt", p.output_colmap.c_str());
     }
+    // Pose is already computed for the glb/colmap export above; honor --pose here
+    // too (previously silently dropped when --glb/--colmap were present).
+    if (!p.output_pose.empty()){
+        if (!da::write_pose_json(p.output_pose, ext, intr)){
+            std::fprintf(stderr, "error: write pose json failed\n"); return 1; }
+        std::printf("wrote %s\n", p.output_pose.c_str());
+    }
     if (!p.output_pfm.empty()) da::write_pfm(p.output_pfm, depth, H, W);
     if (!p.output_png.empty()) da::write_depth_png(p.output_png, depth, H, W, p.invert);
     return 0;


### PR DESCRIPTION
## Problem

`da3-cli depth --input photo.jpg --glb scene.glb --pose pose.json` writes the `.glb` but **silently drops `--pose`** — no JSON file is written and no error/warning is printed.

The pose JSON is only written in the depth-only path (`cmd_depth`). When `--glb` or `--colmap` is requested, dispatch goes to `cmd_depth_export`, which computes the camera pose (`ext`/`intr`) and uses it for the glb/COLMAP writers but never persists `--pose`.

## Fix

`cmd_depth_export` already has `ext`/`intr` in hand — just write the pose JSON when `p.output_pose` is set, mirroring the depth-only path (reuses the existing `da::write_pose_json`). 7 lines, no new computation.

## Verification

Before: `--glb X --pose Y.json` → `Y.json` never created.
After (same command):
```
depth 280x504 min=0.7092 max=1.7822 fx=422.7109 fy=515.7461
wrote scene.glb
wrote pose.json
```
`pose.json` now contains valid `extrinsics` (3x4) + `intrinsics` (3x3). Built clean with `cmake --build` (MinGW/GCC 16, Windows).

Found while evaluating the CLI for a single-shot depth+pose+glb export flow. Thanks for the great port! 🙏