### PR TITLE
fix(cmake): enable winograd AVX-512 on MSVC via /arch:AVX512

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,10 +85,20 @@ target_include_directories(depthanything
 # but our library target does not, so enable them for just winograd.cpp when the
 # host compiler supports them (falls back to a scalar path otherwise).
 include(CheckCXXCompilerFlag)
-check_cxx_compiler_flag("-mavx512f" DA_HAS_AVX512F)
-if(DA_HAS_AVX512F)
-    set_source_files_properties(src/winograd.cpp PROPERTIES
-        COMPILE_OPTIONS "-mavx512f;-mavx512bw;-mfma")
+if(MSVC)
+    # MSVC spells it /arch:AVX512 (implies BW/DQ/VL + FMA) and defines
+    # __AVX512F__ under it, so the same intrinsics path lights up.
+    check_cxx_compiler_flag("/arch:AVX512" DA_HAS_AVX512F)
+    if(DA_HAS_AVX512F)
+        set_source_files_properties(src/winograd.cpp PROPERTIES
+            COMPILE_OPTIONS "/arch:AVX512")
+    endif()
+else()
+    check_cxx_compiler_flag("-mavx512f" DA_HAS_AVX512F)
+    if(DA_HAS_AVX512F)
+        set_source_files_properties(src/winograd.cpp PROPERTIES
+            COMPILE_OPTIONS "-mavx512f;-mavx512bw;-mfma")
+    endif()
 endif()
 target_link_libraries(depthanything PUBLIC ggml)
 


### PR DESCRIPTION
## What

On MSVC, the AVX-512 winograd kernel silently degrades to the scalar fallback. This PR makes the CMake probe compiler-aware so MSVC builds get the intrinsics path too. GCC/Clang builds are byte-for-byte untouched.

## Problem

`CMakeLists.txt` probes the AVX-512 flag only in the GCC/Clang spelling:

```cmake
check_cxx_compiler_flag("-mavx512f" DA_HAS_AVX512F)
```

MSVC rejects `-mavx512f`, so on Windows/MSVC the probe fails:

```
-- Performing Test DA_HAS_AVX512F
-- Performing Test DA_HAS_AVX512F - Failed
```

No error, no warning — `src/winograd.cpp` just compiles without `__AVX512F__` and every 3×3 DPT-head conv runs the scalar GEMV, even on CPUs with full AVX-512 (tested on a Ryzen 7 9700X / Zen 5). ggml itself is unaffected (its own CMake handles MSVC and gets `/arch:AVX512`); the gap is only this repo's winograd kernel.

## Fix

Probe the MSVC spelling when the compiler is MSVC. `/arch:AVX512` implies BW/DQ/VL + FMA and defines `__AVX512F__`/`__AVX512BW__` (verified with a macro probe on MSVC 19.4x), so the existing intrinsics code compiles unchanged — still scoped to `winograd.cpp` only via `set_source_files_properties`, preserving the per-file isolation of the original design. On MSVC toolchains too old to know `/arch:AVX512`, `check_cxx_compiler_flag` fails (unknown-option diagnostic) and the scalar fallback is kept, same as before.

## Numbers

Windows 11, Ryzen 7 9700X (8C/16T, Zen 5), MSVC 19.4x + Ninja, default build flags (`-DDA_BUILD_CLI=ON`), `da3-cli depth --threads 16 --repeat 25`, 504×336, f32 GGUFs, median ms/iter:

| model | before (scalar) | after (AVX-512) | Δ |
|---|---:|---:|---:|
| DA3-SMALL | 180.1 | **164.8** | −8.5% |
| DA3-BASE | 485.6 | **442.5** | −8.9% |

`DA_PROFILE=1` isolates the effect to the DPT head (where the 3×3 convs live): head segment ~103 ms → ~85 ms (−18%) on small; preprocess/backbone unchanged.

Output parity: depth differs from the scalar build only by SIMD summation order — max |d| = 1.2e-6 on `assets/samples/mountains.jpg` (same order as the fused-vs-unfused delta documented in `docs/GPU.md`).

## Testing

- MSVC 19.4x (VS 2022) + Ninja, Windows 11: probe now passes, `/arch:AVX512` lands only on `winograd.cpp.obj` (checked `build.ninja`), benchmarks above.
- Verified `__AVX512F__`/`__AVX512BW__` are defined by MSVC under `/arch:AVX512` with a minimal probe program.
- Non-MSVC path: the `else()` branch is the original block verbatim; Linux/macOS configure output is unchanged.