### PR TITLE
Update tensor retrieval method for layer normalization

### DIFF
--- a/src/dino_backbone.cpp
+++ b/src/dino_backbone.cpp
@@ -239,8 +239,8 @@ bool DinoBackbone::build_feats_graph(ggml_context* ctx, const std::vector<float>
     const std::vector<int32_t>& outL = c.out_layers;
     const size_t NL = outL.size();
 
-    ggml_tensor* nw = ml_.tensor("vit.norm.weight");
-    ggml_tensor* nb = ml_.tensor("vit.norm.bias");
+    ggml_tensor* nw = ml_.host_tensor("vit.norm.weight");
+    ggml_tensor* nb = ml_.host_tensor("vit.norm.bias");
     if (be_.is_offloading()) {
         // vit.norm.* are kept as host gguf tensors (no backend buffer) for the
         // host-side layernorm used by other paths. Here they feed an IN-GRAPH


### PR DESCRIPTION
Change tensor retrieval to use host_tensor for weight and bias to fix SIGSEGV when run in gpu mode.

```gdb
#16 0x0000555555611324 in da::DinoBackbone::build_feats_graph (this=0x7fffffffc300, ctx=0x55555dcf5410, 
    input_chw=std::vector of length 508032, capacity 508032 = {...}, H=336, W=504, pool=..., out_feat=0x7fffffffc1b0)
    at /depth-anything.cpp/src/dino_backbone.cpp:251
#17 0x00005555555f1f1b in operator() (ctx=<optimized out>, __closure=<optimized out>)
    at /depth-anything.cpp/src/engine.cpp:153
#18 std::__invoke_impl<ggml_tensor*, da::Engine::depth_native_fused(const da::Image&, std::vector<float>&, std::vector<float>&, int&, int&)::<lambda(ggml_context*)>&, ggml_context*> (__f=...) at /usr/include/c++/12/bits/invoke.h:61
#19 std::__invoke_r<ggml_tensor*, da::Engine::depth_native_fused(const da::Image&, std::vector<float>&, std::vector<float>&, int&, int&)::<lambda(ggml_context*)>&, ggml_context*> (__fn=...) at /usr/include/c++/12/bits/invoke.h:114
#20 std::_Function_handler<ggml_tensor*(ggml_context*), da::Engine::depth_native_fused(const da::Image&, std::vector<float>&, std::vector<float>&, int&, int&)::<lambda(ggml_context*)> >::_M_invoke(const std::_Any_data &, ggml_context *&&) (__functor=..., __args#0=@0x7fff8edb5900: 0x0)
    at /usr/include/c++/12/bits/std_function.h:290
#21 0x00005555555ccc52 in std::function<ggml_tensor* (ggml_context*)>::operator()(ggml_context*) const (__args#0=<optimized out>, this=0x7fffffffc3a0)
    at /usr/include/c++/12/bits/std_function.h:591
#22 da::Backend::compute(std::function<ggml_tensor* (ggml_context*)> const&, std::vector<float, std::allocator<float> >&, unsigned long) (
    this=this@entry=0x55555dc6dac8, build=..., out=std::vector of length 0, capacity 0, graph_nodes=graph_nodes@entry=0)
    at /depth-anything.cpp/src/backend.cpp:240
#23 0x00005555555f63dd in da::Engine::depth_native_fused (this=0x55555dc6d900, img=..., depth_out=std::vector of length 0, capacity 0, 
    conf_out=std::vector of length 0, capacity 0, H=@0x7fffffffc5b0: 336, W=@0x7fffffffc5d0: 504)
    at /depth-anything.cpp/src/engine.cpp:151
#24 0x00005555555f699d in da::Engine::depth_native (this=0x55555dc6d900, image_path="/gd.jpg", depth_out=std::vector of length 0, capacity 0, 
    conf_out=std::vector of length 0, capacity 0, H=@0x7fffffffc5b0: 336, W=@0x7fffffffc5d0: 504)
    at /depth-anything.cpp/src/engine.cpp:100
#25 0x000055555556baac in cmd_depth (p=...) at /depth-anything.cpp/examples/cli/main.cpp:212
#26 main (argc=<optimized out>, argv=<optimized out>) at /depth-anything.cpp/examples/cli/main.cpp:243
```